### PR TITLE
Update SkillSeeder to prevent duplicates and adjust API route names

### DIFF
--- a/database/seeders/SkillSeeder.php
+++ b/database/seeders/SkillSeeder.php
@@ -114,7 +114,7 @@ class SkillSeeder extends Seeder
         ];
 
         foreach ($skills as $skill) {
-            Skill::create([
+            Skill::firstOrCreate([
                 'name' => $skill
             ]);
         }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -14,7 +14,7 @@ class UserSeeder extends Seeder
      */
     public function run(): void
     {
-        $adminUser = User::create(
+        $adminUser = User::firstOrCreate(
             [
                 "first_name" => "root user",
                 "last_name" => "root user",

--- a/routes/api.php
+++ b/routes/api.php
@@ -421,8 +421,21 @@ Route::group(['prefix' => 'v1/mentorship', 'middleware' => ['cors', 'mentorship'
         Route::apiResource('skill-categories', SkillCategoryController::class);
     });
 
-    Route::resource('mentor', MentorManager::class)->except('index');
-    Route::resource('mentee', MenteeManager::class)->except(['index', 'show']);
+    Route::resource('mentor', MentorManager::class)->except('index')->names([
+
+        'store' => 'mentorship.mentor.store',
+        'update' => 'mentorship.mentor.update',
+        'destroy' => 'mentorship.mentor.destroy',
+        'edit' => 'mentorship.mentor.edit',
+        'create' => 'mentorship.mentor.create',
+    ]);
+    Route::resource('mentee', MenteeManager::class)->except(['index', 'show'])->names([
+        'store' => 'mentorship.mentee.store',
+        'update' => 'mentorship.mentee.update',
+        'destroy' => 'mentorship.mentee.destroy',
+        'edit' => 'mentorship.mentee.edit',
+        'create' => 'mentorship.mentee.create',
+    ]);
     Route::get('mentee-profile', [MenteeManager::class, 'showProfile']);
     Route::get('mentor-profile', [MentorManager::class, 'showProfile']);
     Route::get('event', [EventController::class, 'index']);


### PR DESCRIPTION
- Change SkillSeeder to use `firstOrCreate` for skill insertion, preventing duplicate entries
- Reconfigure mentor/mentee route names to follow consistent 'mentorship.[role].action' pattern
- Maintain excluded routes for mentor/mentee resources while aligning naming conventions
- Preserve profile endpoints and event route structure while improving routing clarity