### PR TITLE
Update UserSeeder to use email lookup and secure password hashing

### DIFF
--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -15,14 +15,16 @@ class UserSeeder extends Seeder
     public function run(): void
     {
         $adminUser = User::firstOrCreate(
+            ['email' => 'root@mail.com'], // Lookup key only
             [
-                "first_name" => "root user",
-                "last_name" => "root user",
-                "email" => "root@mail.com",
-                "password" => "password",
-                "is_admin" => true
+                'first_name' => 'root user',
+                'last_name' => 'root user',
+                'password' => bcrypt('password'), // Always hash!
+                'is_admin' => true,
             ]
         );
+
+        // Verify email timestamp if newly created or already exists
         $adminUser->email_verified_at = Carbon::now();
         $adminUser->save();
     }


### PR DESCRIPTION
- Use email as unique key in firstOrCreate to prevent duplicate admin users
- Hash password with bcrypt instead of storing plaintext
- Set email_verified_at timestamp for admin user during seeding
- Improve code comments for clarity on seeding logic