### PR TITLE
Update JWT secret config key in mentorship auth middleware

### DIFF
--- a/app/Http/Middleware/JWTMentorshipAuth.php
+++ b/app/Http/Middleware/JWTMentorshipAuth.php
@@ -20,7 +20,7 @@ class JWTMentorshipAuth
     public function handle(Request $request, Closure $next): Response
     {
         $jwt = $request->bearerToken();
-        $key = config('jwt.mentorship_secret');
+        $key = config('jwt.secret');
 
         if (!is_string($key) || trim($key) === '') {
             return response()->json(['error' => 'JWT secret key is not properly configured.'], 500);


### PR DESCRIPTION
Change config key from 'jwt.mentorship_secret' to 'jwt.secret' to use unified JWT secret configuration across the application. This aligns with existing JWT implementations and removes the need for a separate mentorship-specific secret key.