### PR TITLE
Fix mentor approval status logic in profile retrieval

### DIFF
--- a/app/Http/Controllers/Mentor/MentorManager.php
+++ b/app/Http/Controllers/Mentor/MentorManager.php
@@ -112,16 +112,13 @@ class MentorManager extends Controller
         if (!$user->mentor) {
             return $this->errorResponse('Mentor data not found', 404);
         }
-
-        if ($user->mentor->status == 'pending') {
-            // If user has user_uuid, update status to approved
-            if ($user->user_uuid) {
+        if ($user->user_uuid) {
             $user->mentor->status = 'approved';
             $user->mentor->save();
-            } else {
+        }
+        if ($user->mentor->status == 'pending') {
             return $this->errorResponse('Your account is pending', 404);
-            }
-        
+
         } else if ($user->mentor->status == 'declined') {
             return $this->errorResponse('Your account is rejected', 404);
         }


### PR DESCRIPTION
Ensure mentor status is updated to approved when user_uuid exists, regardless of initial status. Reorder checks to handle approval before validating status to prevent pending errors after UUID assignment.