### PR TITLE
Make project_id nullable in mentors table

### DIFF
--- a/database/migrations/2025_06_06_004141_rename_project_choice_to_project_id_in_mentors_table.php
+++ b/database/migrations/2025_06_06_004141_rename_project_choice_to_project_id_in_mentors_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
         public function up(): void
         {
             Schema::table('mentors', function (Blueprint $table) {
-                $table->unsignedBigInteger('project_id')->after('resume_link');
+                $table->unsignedBigInteger('project_id')->after('resume_link')->nullable();
                 $table->foreign('project_id')->references('id')->on('projects');
             });
 


### PR DESCRIPTION
Allow null values for project_id column to support unassigned mentors. Maintain foreign key constraint while enabling optional project associations. The migration originally added project_id as required, now updated to reflect optional relationship.