### PR TITLE
Remove return type from Mentor project() method for compatibility

### DIFF
--- a/app/Models/Mentor.php
+++ b/app/Models/Mentor.php
@@ -61,7 +61,7 @@ class Mentor extends Model
     /**
      * Get the project associated with the mentor.
      */
-    public function project(): BelongsTo
+    public function project()
     {
         return $this->belongsTo(Project::class, 'project_reference_id');
     }


### PR DESCRIPTION
The BelongsTo return type declaration was removed from the project() relationship method in the Mentor model to resolve potential compatibility issues with how Eloquent handles relationship return types, ensuring proper query builder functionality.