### PR TITLE
Switch to uploadLarge for handling large files in CloudinaryService

### DIFF
--- a/app/Services/Media/CloudinaryService.php
+++ b/app/Services/Media/CloudinaryService.php
@@ -29,14 +29,16 @@ class CloudinaryService
         return cloudinary()->UploadApi()->destroy($url_id);
     }
 
-    public function storeFiles($file, $folder="product_files"){
-        $fileURL =cloudinary()->uploadFile(
+    public function storeFiles($file, $folder = "product_files")
+    {
+        $fileURL = cloudinary()->uploadLarge(
             $file->getRealPath(),
             [
                 'folder' => $folder,
                 "resource_type" => "auto",
             ]
         );
+
         return [
             $fileURL->getSecurePath(),
             $fileURL->getPublicId(),


### PR DESCRIPTION
Update storeFiles method to use cloudinary()->uploadLarge() instead of uploadFile() to support larger file uploads and improve reliability. Adjust code formatting for parameter alignment and add line breaks for better readability.