### PR TITLE
Update MentorMentee model and migration to reflect table name change

### DIFF
--- a/app/Models/MentorMentee.php
+++ b/app/Models/MentorMentee.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class MentorMentee extends Model
 {
-    protected $table = 'mentor_mentee';
+    protected $table = 'mentor_mentees';
 
     protected $fillable = [
         'mentor_id',

--- a/database/migrations/2025_06_18_000003_create_mentor_mentee_table.php
+++ b/database/migrations/2025_06_18_000003_create_mentor_mentee_table.php
@@ -22,6 +22,6 @@ class CreateMentorMenteeTable extends Migration
 
     public function down()
     {
-        Schema::dropIfExists('mentor_mentee');
+        Schema::dropIfExists('mentor_mentees');
     }
 }


### PR DESCRIPTION
- Changed the table name from 'mentor_mentee' to 'mentor_mentees' in the MentorMentee model.
- Updated the migration file to ensure the drop table command matches the new table name.