### PR TITLE
feat: add appointment retrieval endpoints for mentees

### DIFF
--- a/app/Http/Controllers/Mentee/MenteeManager.php
+++ b/app/Http/Controllers/Mentee/MenteeManager.php
@@ -251,4 +251,45 @@ class MenteeManager extends Controller
 
         return $this->successResponse(['completed_sessions_count' => $count], 200);
     }
+
+    /**
+     * Get all appointments for the authenticated mentee
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getMyAppointments()
+    {
+        $user = auth()->user();
+        $mentee = $user->mentee;
+        if (!$mentee) {
+            return $this->errorResponse('Mentee profile not found', 404);
+        }
+        $appointments = \App\Models\AppointmentMentee::where('mentee_id', $mentee->id)
+            ->with('appointment')
+            ->get()
+            ->pluck('appointment')
+            ->filter(); // Remove nulls if any
+        return $this->successResponse([
+            'appointments' => $appointments
+        ], 200);
+    }
+
+    /**
+     * Get all appointments created by the authenticated mentee (fellows_call)
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getMenteeCreatedAppointments()
+    {
+        $user = auth()->user();
+        $mentee = $user->mentee;
+        if (!$mentee) {
+            return $this->errorResponse('Mentee profile not found', 404);
+        }
+        $appointments = \App\Models\Appointment::where('mentee_id', $mentee->id)
+            ->where('meeting_type', 'fellows_call')
+            ->orderByDesc('scheduled_at')
+            ->get();
+        return $this->successResponse([
+            'appointments' => $appointments
+        ], 200);
+    }
 }

--- a/app/Http/Controllers/Mentor/MentorManager.php
+++ b/app/Http/Controllers/Mentor/MentorManager.php
@@ -499,10 +499,11 @@ class MentorManager extends Controller
     public function createAppointment(Request $request)
     {
         $mentor = auth()->user()->mentor;
-        if (!$mentor) {
-            return $this->errorResponse('Mentor profile not found', 404);
+        $mentee = auth()->user()->mentee;
+        if (!$mentor && !$mentee) {
+            return $this->errorResponse('User is neither a mentor nor a mentee', 403);
         }
-        if ($mentor->status !== 'approved') {
+        if ($mentor && $mentor->status !== 'approved') {
             return $this->errorResponse('Mentor account not approved', 403);
         }
 
@@ -510,12 +511,14 @@ class MentorManager extends Controller
             'title' => 'required|string',
             'meeting_type' => 'nullable|string',
             'meeting_link' => 'nullable|string',
+            'start_meeting_link' => 'nullable|string',
             'description' => 'nullable|string',
             'scheduled_at' => 'required|date',
             'mentee_ids' => 'nullable|array',
             'mentee_ids.*' => 'integer|exists:mentees,id',
             'total_time' => 'nullable|integer', // in minutes
             'scheduled_end' => 'nullable|date',
+            'mentee_id' => 'nullable|integer|exists:mentees,id',
         ]);
 
         $scheduledAt = $validated['scheduled_at'];
@@ -527,26 +530,46 @@ class MentorManager extends Controller
             $scheduledEnd = (new \Carbon\Carbon($scheduledAt))->addMinutes($totalTime);
         }
 
-        // Get all mentees assigned to this mentor if mentee_ids not provided
-        $menteeIds = $validated['mentee_ids'] ?? MentorMentee::where('mentor_id', $mentor->id)->pluck('mentee_id')->toArray();
-        if (empty($menteeIds)) {
-            return $this->errorResponse('No mentees assigned to this mentor', 400);
+        if (($validated['meeting_type'] ?? null) === 'fellows_call') {
+            $appointment = 
+                \App\Models\Appointment::create([
+                    'title' => $validated['title'],
+                    'meeting_type' => $validated['meeting_type'],
+                    'meeting_link' => $validated['meeting_link'] ?? null,
+                    'start_meeting_link' => $validated['start_meeting_link'] ?? null,
+                    'description' => $validated['description'] ?? null,
+                    'scheduled_at' => $scheduledAt,
+                    'scheduled_end' => $scheduledEnd,
+                    'total_time' => $totalTime,
+                    'mentee_id' => $mentee ? $mentee->id : ($validated['mentee_id'] ?? null),
+                    'mentor_id' => null,
+                ]);
+            // Optionally, sync all mentees to this fellows_call if needed
+        } else if ($mentor) {
+            // Get all mentees assigned to this mentor if mentee_ids not provided
+            $menteeIds = $validated['mentee_ids'] ?? MentorMentee::where('mentor_id', $mentor->id)->pluck('mentee_id')->toArray();
+            if (empty($menteeIds)) {
+                return $this->errorResponse('No mentees assigned to this mentor', 400);
+            }
+            $appointment = $mentor->appointments()->create([
+                'title' => $validated['title'],
+                'meeting_type' => $validated['meeting_type'] ?? null,
+                'meeting_link' => $validated['meeting_link'] ?? null,
+                'start_meeting_link' => $validated['start_meeting_link'] ?? null,
+                'description' => $validated['description'] ?? null,
+                'scheduled_at' => $scheduledAt,
+                'scheduled_end' => $scheduledEnd,
+                'total_time' => $totalTime,
+            ]);
+            $appointment->mentees()->sync($menteeIds);
+        } else {
+            return $this->errorResponse('Only mentors can create non-fellows_call appointments', 403);
         }
-
-        $appointment = $mentor->appointments()->create([
-            'title' => $validated['title'],
-            'meeting_type' => $validated['meeting_type'] ?? null,
-            'meeting_link' => $validated['meeting_link'] ?? null,
-            'description' => $validated['description'] ?? null,
-            'scheduled_at' => $scheduledAt,
-            'scheduled_end' => $scheduledEnd,
-            'total_time' => $totalTime,
-        ]);
-        $appointment->mentees()->sync($menteeIds);
 
         return $this->successResponse([
             'message' => 'Appointment created successfully',
             'appointment' => $appointment->load('mentees'),
+            'start_meeting_link' => $appointment->start_meeting_link,
         ], 201);
     }
 
@@ -565,7 +588,14 @@ class MentorManager extends Controller
             return $this->errorResponse('Mentor account not approved', 403);
         }
 
-        $appointments = $mentor->appointments()->with('mentees')->orderByDesc('scheduled_at')->get();
+        $appointments = $mentor->appointments()
+            ->where(function($query) {
+                $query->whereNull('meeting_type')->orWhere('meeting_type', '!=', 'fellows_call');
+            })
+            ->whereNull('mentee_id')
+            ->with('mentees')
+            ->orderByDesc('scheduled_at')
+            ->get();
 
         return $this->successResponse([
             'appointments' => $appointments
@@ -594,7 +624,8 @@ class MentorManager extends Controller
         }
 
         return $this->successResponse([
-            'appointment' => $appointment
+            'appointment' => $appointment,
+            'start_meeting_link' => $appointment->start_meeting_link,
         ], 200);
     }
 
@@ -624,6 +655,7 @@ class MentorManager extends Controller
             'title' => 'sometimes|required|string',
             'meeting_type' => 'nullable|string',
             'meeting_link' => 'nullable|string',
+            'start_meeting_link' => 'nullable|string',
             'description' => 'nullable|string',
             'scheduled_at' => 'nullable|date',
             'mentee_ids' => 'nullable|array',
@@ -636,6 +668,7 @@ class MentorManager extends Controller
             'title' => $validated['title'] ?? $appointment->title,
             'meeting_type' => $validated['meeting_type'] ?? $appointment->meeting_type,
             'meeting_link' => $validated['meeting_link'] ?? $appointment->meeting_link,
+            'start_meeting_link' => $validated['start_meeting_link'] ?? $appointment->start_meeting_link,
             'description' => $validated['description'] ?? $appointment->description,
             'scheduled_at' => $validated['scheduled_at'] ?? $appointment->scheduled_at,
         ];
@@ -660,6 +693,7 @@ class MentorManager extends Controller
         return $this->successResponse([
             'message' => 'Appointment updated successfully',
             'appointment' => $appointment->load('mentees'),
+            'start_meeting_link' => $appointment->start_meeting_link,
         ], 200);
     }
 

--- a/app/Models/Appointment.php
+++ b/app/Models/Appointment.php
@@ -11,9 +11,11 @@ class Appointment extends Model
 
     protected $fillable = [
         'mentor_id',
+        'mentee_id',
         'title',
         'meeting_type',
         'meeting_link',
+        'start_meeting_link',
         'description',
         'scheduled_at',
         'scheduled_end',
@@ -28,5 +30,10 @@ class Appointment extends Model
     public function mentees()
     {
         return $this->belongsToMany(Mentee::class, 'appointment_mentees');
+    }
+
+    public function mentee()
+    {
+        return $this->belongsTo(Mentee::class, 'mentee_id');
     }
 }

--- a/database/migrations/2025_07_21_000000_add_start_meeting_link_to_appointments_table.php
+++ b/database/migrations/2025_07_21_000000_add_start_meeting_link_to_appointments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->string('start_meeting_link')->nullable()->after('meeting_link');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->dropColumn('start_meeting_link');
+        });
+    }
+}; 

--- a/database/migrations/2025_07_22_000000_add_mentee_id_and_nullable_mentor_id_to_appointments_table.php
+++ b/database/migrations/2025_07_22_000000_add_mentee_id_and_nullable_mentor_id_to_appointments_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->unsignedBigInteger('mentee_id')->nullable()->after('mentor_id');
+            $table->unsignedBigInteger('mentor_id')->nullable()->change();
+            $table->foreign('mentee_id')->references('id')->on('mentees')->onDelete('set null');
+            $table->dropForeign(['mentor_id']);
+            $table->foreign('mentor_id')->references('id')->on('mentors')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->dropForeign(['mentee_id']);
+            $table->dropColumn('mentee_id');
+            $table->dropForeign(['mentor_id']);
+            $table->unsignedBigInteger('mentor_id')->nullable(false)->change();
+            $table->foreign('mentor_id')->references('id')->on('mentors')->onDelete('cascade');
+        });
+    }
+}; 

--- a/routes/api.php
+++ b/routes/api.php
@@ -420,6 +420,8 @@ Route::group(['prefix' => 'v1/mentorship', 'middleware' => ['cors', 'mentorship'
         Route::get('/sessions/count', [MenteeManager::class, 'getCompletedSessionsCount']);
         Route::get('/fellow-mentees', [MenteeManager::class, 'getFellowMentees']);
         Route::get('/my-mentor', [MenteeManager::class, 'getMyMentor']);
+        Route::get('/mentee-appointments', [MenteeManager::class, 'getMyAppointments']);
+        Route::get('/mentee-created-appointments', [MenteeManager::class, 'getMenteeCreatedAppointments']);
     });
 
     // Mentor routes


### PR DESCRIPTION
- Introduced new methods in MenteeManager to fetch all appointments for the authenticated mentee and to retrieve appointments created by the mentee.
- Enhanced the Appointment model to include a relationship with the mentee.
- Updated API routes to include new endpoints for these functionalities, improving appointment management for mentees.