### PR TITLE
fix(MenteeManager): ensure course and track fields are strings before…

### DIFF
--- a/app/Http/Controllers/Mentee/MenteeManager.php
+++ b/app/Http/Controllers/Mentee/MenteeManager.php
@@ -105,6 +105,15 @@ class MenteeManager extends Controller
             return $this->errorResponse('Mentee not found', 404);
         }
         $mentee = $user->mentee;
+        
+        // Ensure course and track are strings
+        if ($request->has('course') && !is_string($request->course)) {
+            $request->merge(['course' => (string) $request->course]);
+        }
+        if ($request->has('track') && !is_string($request->track)) {
+            $request->merge(['track' => (string) $request->track]);
+        }
+        
         $validated = $request->validate(\App\Http\Requests\MenteeRequest::$_updateRules);
         $mentee->update($validated);
         // Assign mentor after update


### PR DESCRIPTION
… validation

Add type casting for course and track fields in updateProfile method to prevent validation errors when non-string values are provided.